### PR TITLE
chore(*): 🤖 increase commit description length limit

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -16,7 +16,7 @@ rules:
   header-max-length:
     - 2
     - always
-    - 64
+    - 75
   header-min-length:
     - 2
     - always


### PR DESCRIPTION
* this accounts for renovate's long commit messages sometimes