### PR TITLE
feat(*): ✨ add option `--hook` to help w/ `prepare-commit-msg`

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,3 +1,3 @@
-#!/bin/shx
+#!/bin/sh
 
 npx --no-install commitlint --edit "$1"

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+exec < /dev/tty
+
+node ./dist/index.mjs --commitlint --hook

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ useCommitlintConfig: false
 | `--skip`        | `-S`  | skip questions                                                   |
 | `--no-emoji`    |       | disable all emojis                                               |
 | `--retry`       | `-r`  | retries previous commit, skips all prompts                       |
+| `--hook`        | `-H`  | run `gitzy` inside a Git hook                                    |
 
 <!-- references -->
 

--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,7 @@
     "cosmiconfig",
     "dependabot",
     "deps",
+    "EDITMSG",
     "esbenp",
     "esbuild",
     "gitmoji",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -53,7 +53,7 @@ describe("cli", () => {
           submitted: expect.any(Function),
         },
       },
-      { emoji: true },
+      { emoji: true, hook: undefined },
     );
     expect(checkIfGitSpy).toHaveBeenCalledTimes(1);
     expect(checkIfStagedSpy).toHaveBeenCalledTimes(1);
@@ -64,7 +64,7 @@ describe("cli", () => {
         answers: defaultAnswers,
         config: defaultConfig,
       },
-      { emoji: true },
+      { emoji: true, hook: undefined },
     );
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -83,6 +83,8 @@ export const cli = async (): Promise<void> => {
     .option("-l, --commitlint", lang.flags.commitlint)
     .option("-r, --retry", lang.flags.retry)
     .option("--no-emoji", lang.flags.noEmoji)
+    .option("-H, --hook", lang.flags.hook)
+
     .addOption(options.skip)
     .addHelpText(
       "after",
@@ -94,7 +96,11 @@ Examples:
     .name("gitzy")
 
     .action(async () => {
-      const flags: Flags = program.opts();
+      const opts = program.opts<Flags>();
+      const flags = {
+        ...opts,
+        hook: process.env.GIT_DIR !== undefined || opts.hook,
+      };
 
       if (flags.dryRun) {
         log(info("running in dry mode..."));

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -97,6 +97,7 @@ export interface Flags {
   dryRun?: boolean;
   emoji?: boolean;
   help?: boolean;
+  hook?: boolean;
   issues?: string;
   noEmoji?: boolean;
   passthrough?: string[];

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -29,6 +29,7 @@ export const lang = {
     get dryRun(): string {
       return "displays git message but does not commit";
     },
+    hook: "run gitzy inside a Git hook",
     get issues(): string {
       return skipQuestionMessage("issues");
     },

--- a/src/utils/__snapshots__/lang.test.ts.snap
+++ b/src/utils/__snapshots__/lang.test.ts.snap
@@ -14,6 +14,7 @@ exports[`lang > should create lang 1`] = `
     "breaking": "skip "breaking" question and provide your own "breaking" message",
     "commitlint": "leverage commitlint's configuration",
     "dryRun": "displays git message but does not commit",
+    "hook": "run gitzy inside a Git hook",
     "issues": "skip "issues" question and provide your own "issues" message",
     "noEmoji": "disable all emojis",
     "passthrough": "subsequent command line args passed through to "git"",

--- a/src/utils/executeCommand.ts
+++ b/src/utils/executeCommand.ts
@@ -1,11 +1,11 @@
 import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
 
 import type { Flags, GitzyState } from "../interfaces";
 
 import { formatCommitMessage } from "./format-message";
 import { info, log } from "./logging";
 
-/* istanbul ignore next */
 export const executeCommand = (
   command: string,
   args: string[] = [],
@@ -31,12 +31,18 @@ export const executeDryRun = (message: string): void => {
 
 export const executeGitMessage = (
   { answers, config }: GitzyState,
-  { dryRun = false, emoji = true, passthrough = [] }: Flags,
+  { dryRun = false, emoji = true, hook = false, passthrough = [] }: Flags,
 ): void => {
-  const message = formatCommitMessage(config, answers, emoji);
+  const message = formatCommitMessage(config, answers, emoji, true);
 
   if (dryRun) {
     executeDryRun(message);
+
+    return;
+  }
+
+  if (hook) {
+    writeFileSync(".git/COMMIT_EDITMSG", message);
   } else {
     executeCommand("git", ["commit", "-m", `"${message}"`, ...passthrough]);
   }

--- a/src/utils/format-message/formatGitMessage.test.ts
+++ b/src/utils/format-message/formatGitMessage.test.ts
@@ -216,6 +216,7 @@ describe("formatCommitMessage", () => {
     `);
     expect(formattedMessage.split("\n")[0]).toHaveLength(65);
   });
+
   describe("wrap", () => {
     it("should wrap", () => {
       const wrappedString = wrap(
@@ -228,5 +229,31 @@ describe("formatCommitMessage", () => {
       `);
       expect(wrappedString.split("\n")[0]).toHaveLength(65);
     });
+  });
+
+  it("should format correctly when in hook mode", () => {
+    const formattedMessage = formatCommitMessage(
+      defaultConfig,
+      {
+        body: "this an amazing feature, lots of details",
+        breaking: "breaks everything",
+        issues: "#123",
+        scope: "*",
+        subject: "a cool new `feature`",
+        type: "feat",
+      },
+      true,
+      true,
+    );
+
+    expect(formattedMessage).toMatchInlineSnapshot(`
+      "feat(*): ✨ a cool new \`feature\`
+
+      this an amazing feature, lots of details
+
+      BREAKING CHANGE: 💥 breaks everything
+
+      🏁 Closes: #123"
+    `);
   });
 });

--- a/src/utils/format-message/formatGitMessage.ts
+++ b/src/utils/format-message/formatGitMessage.ts
@@ -43,6 +43,7 @@ export const formatCommitMessage = (
   config: GitzyConfig,
   answers: Answers,
   emoji: boolean,
+  isHook = false,
 ): string => {
   const hasEmoji =
     !config.disableEmoji && config.details[answers.type].emoji && emoji;
@@ -54,5 +55,7 @@ export const formatCommitMessage = (
   const issues = createIssues(answers.issues, config);
   const maxWidth = Math.max(config.headerMaxLength, MAX_WIDTH);
 
-  return normalizeMessage(wrap(`${head}${body}${breaking}${issues}`, maxWidth));
+  const message = wrap(`${head}${body}${breaking}${issues}`, maxWidth);
+
+  return isHook ? message : normalizeMessage(message);
 };


### PR DESCRIPTION
## Pull Request Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Appropriate label or labels have been added
- [x] ✅ Tests for the changes have been added (for `type:fix` / `type:feat`)
- [x] 📝 Docs have been reviewed, added or updated if needed (for `type:fix` / `type:feat`)
- [x] 🏁 Issue number has been linked if this PR closes one

## Description

This PR introduces a new `--hook (-H)` option to improve gitzy’s integration with Git hooks, specifically the prepare-commit-msg hook. This allows gitzy to write the commit message directly to `.git/COMMIT_EDITMSG`, ensuring a seamless workflow when used with tools like Husky or lefthook.

🏁 Closes: #511

## Breaking Change?

- [ ] 💥 Yes
- [x] No

❤️ Thank you for contributing!
