### PR TITLE
fix(*): 🐛 actually support `.mjs` extension in config files

### DIFF
--- a/src/config/loaders/loader.spec.ts
+++ b/src/config/loaders/loader.spec.ts
@@ -3,26 +3,6 @@ import { writeFile } from "node:fs/promises";
 
 import { getSearchPlaces, loadConfig } from "./loader";
 
-const expectedSearchPlaces = [
-  "package.json",
-  ".gitzyrc",
-  ".gitzyrc.json",
-  ".gitzyrc.yaml",
-  ".gitzyrc.yml",
-  ".gitzyrc.js",
-  ".gitzyrc.cjs",
-  "gitzy.config.js",
-  "gitzy.config.cjs",
-  ".config/.gitzyrc",
-  ".config/.gitzyrc.json",
-  ".config/.gitzyrc.yaml",
-  ".config/.gitzyrc.yml",
-  ".config/.gitzyrc.js",
-  ".config/.gitzyrc.cjs",
-  ".config/gitzy.config.js",
-  ".config/gitzy.config.cjs",
-];
-
 describe("searchPlaces", () => {
   afterEach(() => {
     access("./.arc.json", (error) => {
@@ -38,7 +18,31 @@ describe("searchPlaces", () => {
   });
 
   it("should return all search places", () => {
-    expect(getSearchPlaces("gitzy")).toStrictEqual(expectedSearchPlaces);
+    expect(getSearchPlaces("gitzy")).toMatchInlineSnapshot(`
+      [
+        "package.json",
+        ".gitzyrc",
+        ".gitzyrc.json",
+        ".gitzyrc.yaml",
+        ".gitzyrc.yml",
+        ".gitzyrc.js",
+        ".gitzyrc.cjs",
+        ".gitzyrc.mjs",
+        "gitzy.config.js",
+        "gitzy.config.cjs",
+        "gitzy.config.mjs",
+        ".config/.gitzyrc",
+        ".config/.gitzyrc.json",
+        ".config/.gitzyrc.yaml",
+        ".config/.gitzyrc.yml",
+        ".config/.gitzyrc.js",
+        ".config/.gitzyrc.cjs",
+        ".config/.gitzyrc.mjs",
+        ".config/gitzy.config.js",
+        ".config/gitzy.config.cjs",
+        ".config/gitzy.config.mjs",
+      ]
+    `);
   });
 
   it("should return null if no config is found", async () => {

--- a/src/config/loaders/loader.ts
+++ b/src/config/loaders/loader.ts
@@ -14,7 +14,7 @@ interface LoadConfigResult<T> {
   isEmpty?: boolean;
 }
 
-const defaultSearchPlaces = (name: string) => {
+const configVariants = (name: string) => {
   return [
     `.${name}rc`,
     `.${name}rc.json`,
@@ -22,17 +22,21 @@ const defaultSearchPlaces = (name: string) => {
     `.${name}rc.yml`,
     `.${name}rc.js`,
     `.${name}rc.cjs`,
+    `.${name}rc.mjs`,
     `${name}.config.js`,
     `${name}.config.cjs`,
+    `${name}.config.mjs`,
   ];
 };
 
 export const getSearchPlaces = (configName: string) => {
+  const variant = configVariants(configName);
+
   return [
     "package.json",
-    ...defaultSearchPlaces(configName),
-    ...defaultSearchPlaces(configName).map((searchPlace) => {
-      return `.config/${searchPlace}`;
+    ...variant,
+    ...variant.map((place) => {
+      return `.config/${place}`;
     }),
   ];
 };


### PR DESCRIPTION
`lilconfig` newer version support mjs & our README also says so but we've been lying


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for .mjs configuration file formats and .config/ directory resolution for configuration discovery.

* **Tests**
  * Updated test snapshots to reflect expanded configuration file variant patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->