### PR TITLE
fix(cli): 🐛 merge commitlint & gitzy types/scopes

### DIFF
--- a/src/core/config/resolver.spec.ts
+++ b/src/core/config/resolver.spec.ts
@@ -81,6 +81,7 @@ describe("resolveConfig", () => {
 
       expect(result.scopes).toStrictEqual([
         { description: "dependency updates", name: "deps" },
+        { name: "build" },
       ]);
     });
 
@@ -141,7 +142,12 @@ describe("resolveConfig", () => {
 
       expect(result.header.max).toBe(50);
       expect(result.scopes.map((s) => s.name)).toStrictEqual(["ui"]);
-      expect(result.types.map((t) => t.name)).toStrictEqual(["feat", "fix"]);
+      expect(result.types.map((t) => t.name)).toStrictEqual([
+        "feat",
+        "fix",
+        "feature",
+        "bugfix",
+      ]);
     });
 
     it("should use commitlint scopes when gitzy config exists but does not define scopes", async () => {
@@ -256,6 +262,132 @@ describe("resolveConfig", () => {
 
       expect(result.header.max).toBe(100);
       expect(result.header.min).toBe(5);
+    });
+  });
+
+  describe("scope and type union merging", () => {
+    it("should union-merge scopes — gitzy order first, commitlint extras appended", async () => {
+      const gitzyConfig = {
+        scopes: [{ description: "Purchase Plan", name: "pp" }],
+      };
+      const commitlintConfig = {
+        rules: {
+          "scope-enum": [2, "always", ["deps", "home", "pp", "alerts"]],
+        },
+      };
+
+      vi.mocked(loadConfig)
+        .mockResolvedValueOnce(gitzyConfig)
+        .mockResolvedValueOnce(commitlintConfig);
+
+      const result = await resolveConfig();
+
+      expect(result.scopes).toStrictEqual([
+        { description: "Purchase Plan", name: "pp" },
+        { name: "deps" },
+        { name: "home" },
+        { name: "alerts" },
+      ]);
+    });
+
+    it("should keep gitzy scope description when name matches commitlint entry", async () => {
+      const gitzyConfig = {
+        scopes: [{ description: "Purchase Plan", name: "pp" }],
+      };
+      const commitlintConfig = {
+        rules: {
+          "scope-enum": [2, "always", ["pp"]],
+        },
+      };
+
+      vi.mocked(loadConfig)
+        .mockResolvedValueOnce(gitzyConfig)
+        .mockResolvedValueOnce(commitlintConfig);
+
+      const result = await resolveConfig();
+
+      expect(result.scopes).toStrictEqual([
+        { description: "Purchase Plan", name: "pp" },
+      ]);
+    });
+
+    it("should append commitlint scopes not present in gitzy", async () => {
+      const gitzyConfig = {
+        scopes: [{ name: "build" }],
+      };
+      const commitlintConfig = {
+        rules: {
+          "scope-enum": [2, "always", ["api", "ui"]],
+        },
+      };
+
+      vi.mocked(loadConfig)
+        .mockResolvedValueOnce(gitzyConfig)
+        .mockResolvedValueOnce(commitlintConfig);
+
+      const result = await resolveConfig();
+
+      expect(result.scopes.map((s) => s.name)).toStrictEqual([
+        "build",
+        "api",
+        "ui",
+      ]);
+    });
+
+    it("should union-merge types — gitzy order first, commitlint extras appended", async () => {
+      const gitzyConfig = {
+        types: ["feat", "fix"],
+      };
+      const commitlintConfig = {
+        rules: {
+          "type-enum": [2, "always", ["feat", "perf", "fix", "chore"]],
+        },
+      };
+
+      vi.mocked(loadConfig)
+        .mockResolvedValueOnce(gitzyConfig)
+        .mockResolvedValueOnce(commitlintConfig);
+
+      const result = await resolveConfig();
+
+      expect(result.types.map((t) => t.name)).toStrictEqual([
+        "feat",
+        "fix",
+        "perf",
+        "chore",
+      ]);
+    });
+
+    it("should keep gitzy type entry when name matches commitlint entry", async () => {
+      const gitzyConfig = {
+        types: [{ description: "New feature", emoji: "✨", name: "feat" }],
+      };
+      const commitlintConfig = {
+        rules: {
+          "type-enum": [2, "always", ["feat", "fix"]],
+        },
+      };
+
+      vi.mocked(loadConfig)
+        .mockResolvedValueOnce(gitzyConfig)
+        .mockResolvedValueOnce(commitlintConfig);
+
+      const result = await resolveConfig();
+
+      expect(result.types).toStrictEqual([
+        { description: "New feature", emoji: "✨", name: "feat" },
+        { description: "Fix a bug", emoji: "🐛", name: "fix" },
+      ]);
+    });
+
+    it("should return undefined scopes when neither gitzy nor commitlint defines them", async () => {
+      vi.mocked(loadConfig)
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ rules: {} });
+
+      const result = await resolveConfig();
+
+      expect(result.scopes).toStrictEqual([]);
     });
   });
 

--- a/src/core/config/resolver.ts
+++ b/src/core/config/resolver.ts
@@ -5,18 +5,32 @@
  * Merge semantics — gitzy config takes precedence over commitlint:
  * - Nested sections (branch, breaking, emoji, header, issues) are shallow-merged
  *   key-by-key so gitzy values win on a per-key basis.
- * - `types` and `scopes` are replaced wholesale: if the gitzy config defines
- *   either array it is used as-is and the commitlint value is discarded.
- *   To inherit commitlint types/scopes, omit them from the gitzy config.
+ * - `types` and `scopes` are union-merged by name: gitzy entries appear first (in
+ *   gitzy order), with gitzy winning for any name that appears in both. Commitlint
+ *   entries whose names are not present in gitzy are appended at the end.
  */
 
-import type { Config } from "./types";
+import type { Config, ScopeEntry, TypeEntry } from "./types";
 
 import { extractCommitlintRules } from "./commitlint";
 import { CommitlintConfigSchema } from "./commitlint-schema";
 import { loadConfig } from "./loader";
 import { normalizeConfig } from "./normalizer";
 import { ConfigSchema } from "./schema";
+
+const toName = (entry: ScopeEntry | string | TypeEntry) => {
+  return typeof entry === "string" ? entry : entry.name;
+};
+
+const mergeByName = <T extends ScopeEntry | string | TypeEntry>(
+  gitzy: readonly T[],
+  commitlint: readonly T[],
+): readonly T[] => {
+  const gitzyNames = new Set(gitzy.map(toName));
+  const extras = commitlint.filter((e) => !gitzyNames.has(toName(e)));
+
+  return [...gitzy, ...extras];
+};
 
 const mergeConfigs = (base: Config | null, overrides: Config): Config => {
   if (!base) return overrides;
@@ -47,6 +61,14 @@ const mergeConfigs = (base: Config | null, overrides: Config): Config => {
     issues:
       (base.issues ?? overrides.issues)
         ? { ...base.issues, ...overrides.issues }
+        : undefined,
+    scopes:
+      (base.scopes ?? overrides.scopes)
+        ? mergeByName(overrides.scopes ?? [], base.scopes ?? [])
+        : undefined,
+    types:
+      (base.types ?? overrides.types)
+        ? mergeByName(overrides.types ?? [], base.types ?? [])
         : undefined,
   };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration scopes and types are now merged from both gitzy and commitlint sources, with gitzy entries preserved and commitlint additions appended.

* **Tests**
  * Added comprehensive test suite for union merging behavior between gitzy and commitlint configurations.
  * Updated existing tests to validate the new merge semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->