### PR TITLE
fix(prompts): 🐛 add skip hint for long desc prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ header: {
 
 ### `body`
 
-Controls the commit body length validation.
+Controls the commit body length validation. The body prompt is optional — press **Enter** twice (submit an empty line) to skip it.
 
 ```js
 body: {

--- a/src/cli/prompts/body.spec.ts
+++ b/src/cli/prompts/body.spec.ts
@@ -83,6 +83,20 @@ describe("body", () => {
     );
   });
 
+  it("should call multiline with placeholder hint to skip", async () => {
+    const { multiline } = await import("@clack/prompts");
+
+    const factory = setupBody();
+
+    await factory();
+
+    expect(multiline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placeholder: "Optional — press Enter twice to skip",
+      }),
+    );
+  });
+
   describe("validate", () => {
     it("should return min error message when non-empty input is below min", async () => {
       const validate = await getValidate();

--- a/src/cli/prompts/body.ts
+++ b/src/cli/prompts/body.ts
@@ -15,6 +15,7 @@ export const body = ({
     return multiline({
       initialValue: initial?.body,
       message: "Add a longer description",
+      placeholder: "Optional — press Enter twice to skip",
       validate: (value) => {
         const trimmedLength = (value ?? "").trim().length;
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?

Adds skip instructions to the placeholder text for the "Long description" prompt.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Linked issue: #667

## Breaking change?

- [ ] Yes
- [x] No

---

💡 See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README clarified that the commit/message body is optional and can be skipped.

* **Improvements**
  * Multiline body input now displays guidance: it's optional and can be skipped by pressing Enter twice.

* **Tests**
  * Added a test confirming the multiline prompt shows the skip guidance when no autofill is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->