### PR TITLE
fix(config): 🐛 filter types/scopes by commitlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
   "author": "jimmy-guzman @jimmy-guzman",
   "type": "module",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    }
   },
   "bin": "./dist/run.mjs",
   "files": [

--- a/src/cli/prompts/subject.spec.ts
+++ b/src/cli/prompts/subject.spec.ts
@@ -85,7 +85,7 @@ describe("subject", () => {
     expect(text).toHaveBeenCalledWith(
       expect.objectContaining({
         message: "Add a short description",
-        placeholder: "5-50 characters",
+        placeholder: "5-64 characters",
       }),
     );
   });
@@ -106,19 +106,20 @@ describe("subject", () => {
     it("should return actionable max error with characters to remove and remaining budget", async () => {
       const validate = await getValidate({}, { scope: "*", type: "fix" });
 
-      // leadingLabel("fix(*): ") = 8 chars, emoji = 3, max = 50
-      // remaining = 50 - 8 - 3 = 39, input = 54, overBy = 15
-      const input = "testing the short description character counter!!!!!!!";
+      // leadingLabel("fix(*): ") = 8 chars, emoji = 3, max = 64
+      // remaining = 64 - 8 - 3 = 53, input = 68, overBy = 15
+      const input =
+        "testing the short description character counter that is way too long";
 
-      expect(validate(input)).toBe("Remove 15 characters (39 available)");
+      expect(validate(input)).toBe("Remove 15 characters (53 available)");
     });
 
     it("should singularize when one character is over", async () => {
       const validate = await getValidate({}, { scope: "*", type: "feat" });
 
-      // remaining = 50 - 9 - 3 = 38, input = 39, overBy = 1
-      expect(validate("#".repeat(39))).toBe(
-        "Remove 1 character (38 available)",
+      // remaining = 64 - 9 - 3 = 52, input = 53, overBy = 1
+      expect(validate("#".repeat(53))).toBe(
+        "Remove 1 character (52 available)",
       );
     });
 
@@ -140,11 +141,11 @@ describe("subject", () => {
         { scope: "*", type: "feat" },
       );
 
-      // leadingLabel("feat(*): ") = 9 chars, emoji = 3, max = 50
-      // remaining = 50 - 9 - 3 = 38
-      expect(validate("#".repeat(38))).toBeUndefined();
-      expect(validate("#".repeat(39))).toBe(
-        "Remove 1 character (38 available)",
+      // leadingLabel("feat(*): ") = 9 chars, emoji = 3, max = 64
+      // remaining = 64 - 9 - 3 = 52
+      expect(validate("#".repeat(52))).toBeUndefined();
+      expect(validate("#".repeat(53))).toBe(
+        "Remove 1 character (52 available)",
       );
     });
 

--- a/src/core/config/defaults.ts
+++ b/src/core/config/defaults.ts
@@ -66,7 +66,7 @@ export const defaultBodyConfig: BodyConfig = {
 };
 
 export const defaultHeaderConfig: HeaderConfig = {
-  max: 50,
+  max: 64,
   min: 5,
 };
 

--- a/src/core/config/resolver.spec.ts
+++ b/src/core/config/resolver.spec.ts
@@ -121,7 +121,7 @@ describe("resolveConfig", () => {
       );
     });
 
-    it("should merge commitlint rules with gitzy config — gitzy takes precedence", async () => {
+    it("should merge commitlint rules with gitzy config — commitlint constrains types", async () => {
       const gitzyConfig = {
         header: { max: 50 },
         scopes: ["ui"],
@@ -143,8 +143,6 @@ describe("resolveConfig", () => {
       expect(result.header.max).toBe(50);
       expect(result.scopes.map((s) => s.name)).toStrictEqual(["ui"]);
       expect(result.types.map((t) => t.name)).toStrictEqual([
-        "feat",
-        "fix",
         "feature",
         "bugfix",
       ]);
@@ -265,8 +263,8 @@ describe("resolveConfig", () => {
     });
   });
 
-  describe("scope and type union merging", () => {
-    it("should union-merge scopes — gitzy order first, commitlint extras appended", async () => {
+  describe("scope and type constrained merging", () => {
+    it("should constrain scopes — gitzy entries in commitlint first, commitlint extras appended", async () => {
       const gitzyConfig = {
         scopes: [{ description: "Purchase Plan", name: "pp" }],
       };
@@ -311,7 +309,7 @@ describe("resolveConfig", () => {
       ]);
     });
 
-    it("should append commitlint scopes not present in gitzy", async () => {
+    it("should exclude gitzy scopes not in commitlint and append commitlint extras", async () => {
       const gitzyConfig = {
         scopes: [{ name: "build" }],
       };
@@ -327,14 +325,10 @@ describe("resolveConfig", () => {
 
       const result = await resolveConfig();
 
-      expect(result.scopes.map((s) => s.name)).toStrictEqual([
-        "build",
-        "api",
-        "ui",
-      ]);
+      expect(result.scopes.map((s) => s.name)).toStrictEqual(["api", "ui"]);
     });
 
-    it("should union-merge types — gitzy order first, commitlint extras appended", async () => {
+    it("should constrain types — gitzy entries in commitlint first, commitlint extras appended", async () => {
       const gitzyConfig = {
         types: ["feat", "fix"],
       };
@@ -378,6 +372,44 @@ describe("resolveConfig", () => {
         { description: "New feature", emoji: "✨", name: "feat" },
         { description: "Fix a bug", emoji: "🐛", name: "fix" },
       ]);
+    });
+
+    it("should exclude gitzy types not in commitlint enum", async () => {
+      const gitzyConfig = {
+        types: ["feat", "fix", "chore", "docs"],
+      };
+      const commitlintConfig = {
+        rules: {
+          "type-enum": [2, "always", ["feat", "fix"]],
+        },
+      };
+
+      vi.mocked(loadConfig)
+        .mockResolvedValueOnce(gitzyConfig)
+        .mockResolvedValueOnce(commitlintConfig);
+
+      const result = await resolveConfig();
+
+      expect(result.types.map((t) => t.name)).toStrictEqual(["feat", "fix"]);
+    });
+
+    it("should exclude gitzy scopes not in commitlint enum", async () => {
+      const gitzyConfig = {
+        scopes: ["api", "ui", "internal"],
+      };
+      const commitlintConfig = {
+        rules: {
+          "scope-enum": [2, "always", ["api", "ui"]],
+        },
+      };
+
+      vi.mocked(loadConfig)
+        .mockResolvedValueOnce(gitzyConfig)
+        .mockResolvedValueOnce(commitlintConfig);
+
+      const result = await resolveConfig();
+
+      expect(result.scopes.map((s) => s.name)).toStrictEqual(["api", "ui"]);
     });
 
     it("should return undefined scopes when neither gitzy nor commitlint defines them", async () => {

--- a/src/core/config/resolver.ts
+++ b/src/core/config/resolver.ts
@@ -5,9 +5,11 @@
  * Merge semantics — gitzy config takes precedence over commitlint:
  * - Nested sections (branch, breaking, emoji, header, issues) are shallow-merged
  *   key-by-key so gitzy values win on a per-key basis.
- * - `types` and `scopes` are union-merged by name: gitzy entries appear first (in
- *   gitzy order), with gitzy winning for any name that appears in both. Commitlint
- *   entries whose names are not present in gitzy are appended at the end.
+ * - `types` and `scopes` are constrained by commitlint when both configs define them:
+ *   commitlint's enum is the authoritative allowed set. Gitzy entries whose names
+ *   appear in the commitlint enum are kept first (in gitzy order, preserving gitzy
+ *   metadata). Commitlint entries not present in gitzy are appended at the end.
+ *   Gitzy entries NOT in the commitlint enum are excluded.
  */
 
 import type { Config, ScopeEntry, TypeEntry } from "./types";
@@ -22,14 +24,16 @@ const toName = (entry: ScopeEntry | string | TypeEntry) => {
   return typeof entry === "string" ? entry : entry.name;
 };
 
-const mergeByName = <T extends ScopeEntry | string | TypeEntry>(
+const constrainByName = <T extends ScopeEntry | string | TypeEntry>(
   gitzy: readonly T[],
   commitlint: readonly T[],
 ): readonly T[] => {
+  const commitlintNames = new Set(commitlint.map(toName));
   const gitzyNames = new Set(gitzy.map(toName));
+  const allowed = gitzy.filter((e) => commitlintNames.has(toName(e)));
   const extras = commitlint.filter((e) => !gitzyNames.has(toName(e)));
 
-  return [...gitzy, ...extras];
+  return [...allowed, ...extras];
 };
 
 const mergeConfigs = (base: Config | null, overrides: Config): Config => {
@@ -63,13 +67,13 @@ const mergeConfigs = (base: Config | null, overrides: Config): Config => {
         ? { ...base.issues, ...overrides.issues }
         : undefined,
     scopes:
-      (base.scopes ?? overrides.scopes)
-        ? mergeByName(overrides.scopes ?? [], base.scopes ?? [])
-        : undefined,
+      base.scopes && overrides.scopes
+        ? constrainByName(overrides.scopes, base.scopes)
+        : (overrides.scopes ?? base.scopes),
     types:
-      (base.types ?? overrides.types)
-        ? mergeByName(overrides.types ?? [], base.types ?? [])
-        : undefined,
+      base.types && overrides.types
+        ? constrainByName(overrides.types, base.types)
+        : (overrides.types ?? base.types),
   };
 };
 

--- a/src/core/init/init.ts
+++ b/src/core/init/init.ts
@@ -21,7 +21,7 @@ const CONFIG_TEMPLATE = `${JSON.stringify(
       enabled: true,
     },
     header: {
-      max: 50,
+      max: 64,
       min: 5,
     },
     issues: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration merging now respects commitlint-defined types and scopes, ensuring only compatible entries are used while preserving richer metadata.

* **New Features**
  * Increased header/subject character limit from 50 to 64.
  * Initialization template updated to include an expanded emoji block and the new header limit.

* **Tests**
  * Expanded tests cover the revised merge behavior, updated header limit, and related normalization/validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->