### PR TITLE
feat: ✨ add signoff flag and prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - Dynamic scopes and types (string shorthand or full `{ name, description }` objects)
 - Jira and GitHub issue reference patterns
 - Co-author support via `--co-author`
+- Sign-off (DCO) support via `--signoff` / `-s` (derives your git identity, or pass an override)
 - Retry (`--retry`), dry-run (`--dry-run`), amend (`--amend`), and hook (`--hook`) modes
 - JSON output (`--json`) for scripting and CI
 - `--no-emoji` flag (precedence: `--no-emoji` > `GITZY_NO_EMOJI` env > `emoji.enabled` config)
@@ -67,25 +68,26 @@ gitzy branch --type feat -m "add dark mode" --scope ui
 
 ### `gitzy commit` flags
 
-| Flag                        | Alias | Description                                                     |
-| --------------------------- | ----- | --------------------------------------------------------------- |
-| `--type <type>`             |       | set type inline (with `--subject`, skips all prompts)           |
-| `--scope <scope>`           |       | set scope inline                                                |
-| `--subject <subject>`       | `-m`  | set subject inline (with `--type`, skips all prompts)           |
-| `--body <body>`             |       | set body inline                                                 |
-| `--breaking [breaking]`     |       | mark as breaking; add message for `footer`/`both` formats       |
-| `--issue <issue...>`        |       | set issues inline (repeatable: `--issue '#123' --issue '#456'`) |
-| `--dry-run`                 | `-D`  | show commit message without committing                          |
-| `--retry`                   |       | retry last commit and skip prompts                              |
-| `--amend`                   | `-a`  | amend the previous commit (pre-fills prompts from HEAD)         |
-| `--no-verify`               | `-n`  | skip git hooks                                                  |
-| `--json`                    |       | output structured JSON (see shape below)                        |
-| `--no-emoji`                |       | disable emoji in commit message                                 |
-| `--co-author <coAuthor...>` |       | add co-authors (repeatable: `--co-author "Name <email>"`)       |
-| `--hook`                    |       | enable running inside a git hook (e.g. `pre-commit`)            |
-| `--stdin`                   |       | read answers from stdin as JSON (CLI flags take priority)       |
-| `--version`                 | `-v`  | display version number                                          |
-| `--help`                    | `-h`  | display help for command                                        |
+| Flag                        | Alias | Description                                                                                |
+| --------------------------- | ----- | ------------------------------------------------------------------------------------------ |
+| `--type <type>`             |       | set type inline (with `--subject`, skips all prompts)                                      |
+| `--scope <scope>`           |       | set scope inline                                                                           |
+| `--subject <subject>`       | `-m`  | set subject inline (with `--type`, skips all prompts)                                      |
+| `--body <body>`             |       | set body inline                                                                            |
+| `--breaking [breaking]`     |       | mark as breaking; add message for `footer`/`both` formats                                  |
+| `--issue <issue...>`        |       | set issues inline (repeatable: `--issue '#123' --issue '#456'`)                            |
+| `--dry-run`                 | `-D`  | show commit message without committing                                                     |
+| `--retry`                   |       | retry last commit and skip prompts                                                         |
+| `--amend`                   | `-a`  | amend the previous commit (pre-fills prompts from HEAD)                                    |
+| `--no-verify`               | `-n`  | skip git hooks                                                                             |
+| `--json`                    |       | output structured JSON (see shape below)                                                   |
+| `--no-emoji`                |       | disable emoji in commit message                                                            |
+| `--co-author <coAuthor...>` |       | add co-authors (repeatable: `--co-author "Name <email>"`)                                  |
+| `--signoff [signoff]`       | `-s`  | add a Signed-off-by trailer (derives your git identity; pass `"Name <email>"` to override) |
+| `--hook`                    |       | enable running inside a git hook (e.g. `pre-commit`)                                       |
+| `--stdin`                   |       | read answers from stdin as JSON (CLI flags take priority)                                  |
+| `--version`                 | `-v`  | display version number                                                                     |
+| `--help`                    | `-h`  | display help for command                                                                   |
 
 #### `commit --json` output shape
 
@@ -102,7 +104,8 @@ gitzy branch --type feat -m "add dark mode" --scope ui
     "body": "",
     "breaking": "",
     "issues": [],
-    "coAuthors": []
+    "coAuthors": [],
+    "signoff": false
   }
 }
 ```
@@ -197,7 +200,7 @@ Controls which prompts are shown and in what order.
 // Default:
 prompts: ["type", "scope", "subject", "body", "breaking", "issues"];
 
-// All available prompts (add "coAuthors" to enable co-author prompt):
+// All available prompts (add "coAuthors"/"signoff" to enable those prompts):
 prompts: [
   "type",
   "scope",
@@ -206,8 +209,16 @@ prompts: [
   "breaking",
   "issues",
   "coAuthors",
+  "signoff",
 ];
 ```
+
+> [!NOTE]
+> The `signoff` prompt is a text input prefilled with your git identity (edit to
+> customize, clear to skip) that adds a `Signed-off-by` trailer. It is opt-in
+> (not in the default `prompts`). The `--signoff` / `-s` flag works regardless
+> of this config, and accepts an optional `"Name <email>"` to override the
+> derived identity.
 
 ### `header`
 

--- a/e2e/e2e.spec.ts
+++ b/e2e/e2e.spec.ts
@@ -275,6 +275,18 @@ describe("gitzy", () => {
         Co-authored-by: Alice <alice@example.com>"
       `);
     });
+
+    it("should add an explicit Signed-off-by override via --signoff", async () => {
+      const result = await runCommit(
+        '--type feat -m add-endpoint --signoff "Bot <bot@example.com>"',
+      );
+
+      expect(result).toMatchInlineSnapshot(`
+        "feat: ✨ add-endpoint
+
+        Signed-off-by: Bot <bot@example.com>"
+      `);
+    });
   });
 
   describe("branch", () => {

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -3,6 +3,7 @@ import { defaultResolvedConfig } from "./core/config/defaults";
 import * as config from "./core/config/resolver";
 import * as gitChecks from "./core/git/checks";
 import * as gitOperations from "./core/git/operations";
+import * as gitSignoff from "./core/git/signoff";
 
 vi.mock("@clack/prompts", () => {
   return {
@@ -95,6 +96,51 @@ describe("cli", () => {
     expect(performCommitSpy).toHaveBeenCalledWith(
       expect.stringContaining(""),
       expect.objectContaining({ noVerify: true }),
+    );
+  });
+
+  it("should derive the Signed-off-by trailer when -s is used", async () => {
+    const performCommitSpy = vi
+      .spyOn(gitOperations, "commit")
+      .mockResolvedValueOnce({ committed: true, message: "" });
+
+    vi.spyOn(gitSignoff, "getSignoffTrailer").mockResolvedValueOnce(
+      "Test User <test@example.com>",
+    );
+    vi.spyOn(gitChecks, "checkIfGitRepo").mockResolvedValueOnce("");
+    vi.spyOn(gitChecks, "checkIfStaged").mockResolvedValueOnce("");
+    vi.spyOn(config, "resolveConfig").mockResolvedValueOnce(
+      defaultResolvedConfig,
+    );
+
+    process.argv = ["node", "gitzy", "-s"];
+
+    await cli();
+
+    expect(performCommitSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Signed-off-by: Test User <test@example.com>"),
+      expect.any(Object),
+    );
+  });
+
+  it("should use an explicit Signed-off-by override verbatim", async () => {
+    const performCommitSpy = vi
+      .spyOn(gitOperations, "commit")
+      .mockResolvedValueOnce({ committed: true, message: "" });
+
+    vi.spyOn(gitChecks, "checkIfGitRepo").mockResolvedValueOnce("");
+    vi.spyOn(gitChecks, "checkIfStaged").mockResolvedValueOnce("");
+    vi.spyOn(config, "resolveConfig").mockResolvedValueOnce(
+      defaultResolvedConfig,
+    );
+
+    process.argv = ["node", "gitzy", "--signoff", "Bot <bot@example.com>"];
+
+    await cli();
+
+    expect(performCommitSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Signed-off-by: Bot <bot@example.com>"),
+      expect.any(Object),
     );
   });
 

--- a/src/cli/commands/commit.ts
+++ b/src/cli/commands/commit.ts
@@ -24,6 +24,7 @@ import {
   shouldDoGitChecks,
 } from "@/core/git/checks";
 import { commit } from "@/core/git/operations";
+import { getSignoffTrailer } from "@/core/git/signoff";
 import { GitzyStore } from "@/core/store/store";
 import { lang } from "@/lang";
 
@@ -86,6 +87,7 @@ export const registerCommitCommand = (program: Command) => {
     .option("--hook", lang.commit.flags.hook)
     .option("-a, --amend", lang.commit.flags.amend)
     .addOption(noVerifyOption)
+    .option("-s, --signoff [signoff]", lang.commit.flags.signoff)
     .option("--co-author <coAuthor...>", lang.commit.flags.coAuthor)
     .option("--stdin", lang.commit.flags.stdin)
     .addHelpText("after", `\nExamples:\n      ${lang.commit.examples}\n    `)
@@ -179,6 +181,7 @@ export const registerCommitCommand = (program: Command) => {
             : { coAuthors: flags.coAuthor }),
           ...(flags.issue === undefined ? {} : { issues: flags.issue }),
           ...(flags.scope === undefined ? {} : { scope: flags.scope }),
+          ...(flags.signoff === undefined ? {} : { signoff: flags.signoff }),
           ...(flags.subject === undefined ? {} : { subject: flags.subject }),
           ...(flags.type === undefined ? {} : { type: flags.type }),
         };
@@ -196,6 +199,14 @@ export const registerCommitCommand = (program: Command) => {
 
         if (flags.coAuthor) {
           state.answers.coAuthors = flags.coAuthor;
+        }
+
+        if (flags.signoff) {
+          state.answers.signoff = flags.signoff;
+        }
+
+        if (state.answers.signoff === true) {
+          state.answers.signoff = await getSignoffTrailer();
         }
 
         const emojiEnabled =

--- a/src/cli/prompts/create-prompts.spec.ts
+++ b/src/cli/prompts/create-prompts.spec.ts
@@ -2,6 +2,12 @@ import { defaultResolvedConfig } from "@/core/config/defaults";
 
 import { createPrompts } from "./create-prompts";
 
+vi.mock("@/core/git/signoff", () => {
+  return {
+    getSignoffTrailer: vi.fn().mockResolvedValue("Jane Doe <jane@example.com>"),
+  };
+});
+
 vi.mock("@clack/prompts", () => {
   return {
     autocomplete: vi.fn().mockResolvedValue("feat"),
@@ -84,6 +90,7 @@ describe("createPrompts", () => {
       coAuthors: [],
       issues: [],
       scope: "",
+      signoff: false,
       subject: "",
       type: "feat",
     });
@@ -176,8 +183,58 @@ describe("createPrompts", () => {
       coAuthors: [],
       issues: ["#123"],
       scope: "",
+      signoff: false,
       subject: "my subject",
       type: "fix",
     });
+  });
+
+  it("should include the signoff prompt only when configured", async () => {
+    const { group } = await import("@clack/prompts");
+
+    await createPrompts(
+      {
+        answers: {
+          body: "",
+          breaking: "",
+          issues: [],
+          scope: "",
+          subject: "",
+          type: "",
+        },
+        config: { ...defaultResolvedConfig, prompts: ["type", "signoff"] },
+      },
+      {},
+    );
+
+    const groupCall = vi.mocked(group).mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+
+    expect(Object.keys(groupCall)).toStrictEqual(["type", "signoff"]);
+  });
+
+  it("should pass through the signoff signature from the text prompt", async () => {
+    const clack = vi.mocked(await import("@clack/prompts"));
+
+    clack.text.mockResolvedValue("Jane Doe <jane@example.com>");
+
+    const result = await createPrompts(
+      {
+        answers: {
+          body: "",
+          breaking: "",
+          issues: [],
+          scope: "",
+          subject: "",
+          type: "",
+        },
+        config: { ...defaultResolvedConfig, prompts: ["signoff"] },
+      },
+      {},
+    );
+
+    expect(result.signoff).toBe("Jane Doe <jane@example.com>");
   });
 });

--- a/src/cli/prompts/create-prompts.ts
+++ b/src/cli/prompts/create-prompts.ts
@@ -10,6 +10,7 @@ import { breaking } from "./breaking";
 import { coAuthors } from "./coAuthors";
 import { issues } from "./issues";
 import { scope } from "./scope";
+import { signoff } from "./signoff";
 import { subject } from "./subject";
 import { type } from "./type";
 
@@ -19,6 +20,7 @@ const prompts = {
   coAuthors,
   issues,
   scope,
+  signoff,
   subject,
   type,
 } as const;
@@ -29,6 +31,7 @@ interface RawGroupResult {
   coAuthors?: string;
   issues?: string;
   scope?: string;
+  signoff?: boolean | string;
   subject?: string;
   type?: string;
 }
@@ -100,6 +103,7 @@ export const createPrompts = async (
       typeof result.issues === "string" ? result.issues : undefined,
     ),
     scope: result.scope ?? "",
+    signoff: result.signoff ?? false,
     subject: result.subject ?? "",
     type: result.type ?? "",
   };

--- a/src/cli/prompts/signoff.spec.ts
+++ b/src/cli/prompts/signoff.spec.ts
@@ -1,0 +1,91 @@
+import type { Answers } from "@/cli/types";
+
+import { defaultResolvedConfig } from "@/core/config/defaults";
+
+import { signoff } from "./signoff";
+
+vi.mock("@clack/prompts", () => ({
+  text: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("@/core/git/signoff", () => {
+  return {
+    getSignoffTrailer: vi.fn().mockResolvedValue("Jane Doe <jane@example.com>"),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const emptyAnswers: Answers = {
+  body: "",
+  breaking: "",
+  issues: [],
+  scope: "",
+  subject: "",
+  type: "",
+};
+
+const setupSignoff = (autofill = {}) => {
+  return signoff({
+    answers: emptyAnswers,
+    autofill,
+    config: defaultResolvedConfig,
+    flags: {},
+  });
+};
+
+describe("signoff", () => {
+  it("should return a factory function", () => {
+    const factory = setupSignoff();
+
+    expect(factory).toBeTypeOf("function");
+  });
+
+  it("should return the boolean autofill value verbatim", async () => {
+    const factory = setupSignoff({ signoff: true });
+
+    await expect(factory()).resolves.toBe(true);
+  });
+
+  it("should return the string autofill override verbatim", async () => {
+    const factory = setupSignoff({ signoff: "Bot <bot@example.com>" });
+
+    await expect(factory()).resolves.toBe("Bot <bot@example.com>");
+  });
+
+  it("should prefill the text prompt with the derived git identity", async () => {
+    const { text } = await import("@clack/prompts");
+
+    const factory = setupSignoff();
+
+    await factory();
+
+    expect(text).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialValue: "Jane Doe <jane@example.com>",
+        message: "Signed-off-by",
+      }),
+    );
+  });
+
+  it("should prefill with the prior signature when amending", async () => {
+    const { text } = await import("@clack/prompts");
+
+    const factory = signoff({
+      answers: emptyAnswers,
+      config: defaultResolvedConfig,
+      flags: {},
+      initial: { ...emptyAnswers, signoff: "Prev <prev@example.com>" },
+    });
+
+    await factory();
+
+    expect(text).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialValue: "Prev <prev@example.com>",
+      }),
+    );
+  });
+});

--- a/src/cli/prompts/signoff.ts
+++ b/src/cli/prompts/signoff.ts
@@ -6,12 +6,10 @@ import { getSignoffTrailer } from "@/core/git/signoff";
 
 export const signoff = ({ autofill, initial }: CreatedPromptOptions) => {
   return async () => {
-    // Flag override (`-s` → true, `--signoff "X"` → string) skips the prompt.
     if (autofill?.signoff !== undefined) {
       return autofill.signoff;
     }
 
-    // Prefer the prior signature when amending; otherwise derive from git.
     const initialValue =
       typeof initial?.signoff === "string"
         ? initial.signoff

--- a/src/cli/prompts/signoff.ts
+++ b/src/cli/prompts/signoff.ts
@@ -1,0 +1,26 @@
+import { text } from "@clack/prompts";
+
+import type { CreatedPromptOptions } from "@/cli/types";
+
+import { getSignoffTrailer } from "@/core/git/signoff";
+
+export const signoff = ({ autofill, initial }: CreatedPromptOptions) => {
+  return async () => {
+    // Flag override (`-s` → true, `--signoff "X"` → string) skips the prompt.
+    if (autofill?.signoff !== undefined) {
+      return autofill.signoff;
+    }
+
+    // Prefer the prior signature when amending; otherwise derive from git.
+    const initialValue =
+      typeof initial?.signoff === "string"
+        ? initial.signoff
+        : await getSignoffTrailer();
+
+    return text({
+      initialValue,
+      message: "Signed-off-by",
+      placeholder: "leave empty to skip",
+    });
+  };
+};

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -25,6 +25,7 @@ export interface CommitFlags {
   noVerify?: boolean;
   retry?: boolean;
   scope?: string;
+  signoff?: boolean | string;
   stdin?: boolean;
   subject?: string;
   type?: string;

--- a/src/core/config/defaults.ts
+++ b/src/core/config/defaults.ts
@@ -15,6 +15,7 @@ export const availablePrompts = [
   "coAuthors",
   "issues",
   "scope",
+  "signoff",
   "subject",
   "type",
 ] as const;

--- a/src/core/conventional/message.spec.ts
+++ b/src/core/conventional/message.spec.ts
@@ -539,6 +539,54 @@ describe("formatCommitMessage", () => {
       Co-authored-by: Bob <bob@example.com>"
     `);
   });
+
+  it("should include Signed-off-by footer when signoff is a string", () => {
+    const formattedMessage = setupFormatCommitMessage(defaultResolvedConfig, {
+      signoff: "Jane Doe <jane@example.com>",
+    });
+
+    expect(formattedMessage).toMatchInlineSnapshot(`
+      "feat(*): ✨ a cool new feature
+
+      this an amazing feature, lots of details
+
+      BREAKING CHANGE: 💥 breaks everything
+
+      🏁 Closes #123
+
+      Signed-off-by: Jane Doe <jane@example.com>"
+    `);
+  });
+
+  it("should NOT include Signed-off-by footer when signoff is an unresolved boolean", () => {
+    const formattedMessage = setupFormatCommitMessage(defaultResolvedConfig, {
+      signoff: true,
+    });
+
+    expect(formattedMessage).toMatchInlineSnapshot(`
+      "feat(*): ✨ a cool new feature
+
+      this an amazing feature, lots of details
+
+      BREAKING CHANGE: 💥 breaks everything
+
+      🏁 Closes #123"
+    `);
+  });
+
+  it("should NOT include Signed-off-by footer when signoff is omitted", () => {
+    const formattedMessage = setupFormatCommitMessage(defaultResolvedConfig, {
+      breaking: "",
+      issues: [],
+      signoff: false,
+    });
+
+    expect(formattedMessage).toMatchInlineSnapshot(`
+      "feat(*): ✨ a cool new feature
+
+      this an amazing feature, lots of details"
+    `);
+  });
 });
 
 describe("formatMessageResult", () => {
@@ -728,6 +776,23 @@ describe("formatMessageResult", () => {
         },
       }
     `);
+  });
+
+  it("should classify Signed-off-by as footer", () => {
+    const result = setupFormatMessageResult(
+      {},
+      {
+        body: "a description",
+        signoff: "Jane Doe <jane@example.com>",
+        subject: "a feature",
+        type: "feat",
+      },
+    );
+
+    expect(result.body).toMatchInlineSnapshot(`"a description"`);
+    expect(result.footer).toMatchInlineSnapshot(
+      `"Signed-off-by: Jane Doe <jane@example.com>"`,
+    );
   });
 });
 

--- a/src/core/conventional/message.ts
+++ b/src/core/conventional/message.ts
@@ -98,9 +98,13 @@ const createCoAuthors = (coAuthors: string[] | undefined) => {
 };
 
 const createSignoff = (signoff: MessageParts["signoff"]) => {
-  if (typeof signoff !== "string" || !signoff.trim()) return "";
+  if (typeof signoff !== "string") return "";
 
-  return `\n\nSigned-off-by: ${signoff}`;
+  const trimmed = signoff.trim();
+
+  if (!trimmed) return "";
+
+  return `\n\nSigned-off-by: ${trimmed}`;
 };
 
 const createScope = (scope: string) => {

--- a/src/core/conventional/message.ts
+++ b/src/core/conventional/message.ts
@@ -97,6 +97,12 @@ const createCoAuthors = (coAuthors: string[] | undefined) => {
   return `\n\n${coAuthors.map((author) => `Co-authored-by: ${author}`).join("\n")}`;
 };
 
+const createSignoff = (signoff: MessageParts["signoff"]) => {
+  if (typeof signoff !== "string" || !signoff.trim()) return "";
+
+  return `\n\nSigned-off-by: ${signoff}`;
+};
+
 const createScope = (scope: string) => {
   return scope && scope !== "none" ? `(${scope})` : "";
 };
@@ -154,9 +160,13 @@ export const formatMessage = (
   const breaking = createBreaking(parts.breaking, config, emojiEnabled);
   const issues = createIssues(parts.issues, config, emojiEnabled);
   const coAuthors = createCoAuthors(parts.coAuthors);
+  const signoff = createSignoff(parts.signoff);
   const maxWidth = Math.max(config.header.max, MAX_WIDTH);
 
-  return wrap(`${head}${body}${breaking}${issues}${coAuthors}`, maxWidth);
+  return wrap(
+    `${head}${body}${breaking}${issues}${coAuthors}${signoff}`,
+    maxWidth,
+  );
 };
 
 /**
@@ -190,6 +200,7 @@ const getFooterStartRegex = (config: ResolvedConfig) => {
   const patterns = [
     "BREAKING[ -]CHANGE:",
     "Co-authored-by:",
+    "Signed-off-by:",
     ...new Set(configValues),
   ];
 

--- a/src/core/conventional/types.ts
+++ b/src/core/conventional/types.ts
@@ -12,6 +12,11 @@ export interface MessageParts {
   coAuthors?: string[];
   issues: string[];
   scope: string;
+  /**
+   * Signed-off-by trailer. `true` means derive the identity from git (resolved
+   * to a "Name <email>" string before formatting); a string is used verbatim.
+   */
+  signoff?: boolean | string;
   subject: string;
   type: string;
 }

--- a/src/core/git/amend.spec.ts
+++ b/src/core/git/amend.spec.ts
@@ -128,6 +128,19 @@ describe("parseConventionalCommit", () => {
     });
   });
 
+  it("should capture the Signed-off-by signature and keep it out of the body", () => {
+    const result = parseConventionalCommit(
+      "feat: add feature\n\nThis is the body.\n\nSigned-off-by: Jane Doe <jane@example.com>",
+    );
+
+    expect(result).toStrictEqual({
+      body: "This is the body.",
+      signoff: "Jane Doe <jane@example.com>",
+      subject: "add feature",
+      type: "feat",
+    });
+  });
+
   it("should handle scope with breaking ! indicator", () => {
     const result = parseConventionalCommit(
       "refactor(core)!: rewrite internals\n\nBREAKING CHANGE: new API shape",

--- a/src/core/git/amend.ts
+++ b/src/core/git/amend.ts
@@ -94,7 +94,7 @@ export const parseConventionalCommit = (message: string): ParsedCommit => {
       .filter(Boolean);
   }
 
-  const signoffMatch = /^Signed-off-by:(?<signoff>.+)$/m.exec(rest);
+  const signoffMatch = /^Signed-off-by:(?<signoff>.+)$/im.exec(rest);
   const signoff = signoffMatch?.groups?.signoff.trim();
 
   if (signoff) {

--- a/src/core/git/amend.ts
+++ b/src/core/git/amend.ts
@@ -13,7 +13,7 @@ import type { MessageParts } from "@/core/conventional/types";
 type ParsedCommit = Partial<
   Pick<
     MessageParts,
-    "body" | "breaking" | "issues" | "scope" | "subject" | "type"
+    "body" | "breaking" | "issues" | "scope" | "signoff" | "subject" | "type"
   >
 >;
 
@@ -71,7 +71,7 @@ export const parseConventionalCommit = (message: string): ParsedCommit => {
   if (scope) result.scope = scope;
 
   const footerStart = rest.search(
-    /^(?:\p{Emoji_Presentation}\s)?(?:BREAKING[ -]CHANGE|Co-authored-by|Closes|Fixes|Resolves)/imu,
+    /^(?:\p{Emoji_Presentation}\s)?(?:BREAKING[ -]CHANGE|Co-authored-by|Signed-off-by|Closes|Fixes|Resolves)/imu,
   );
   const bodyText =
     footerStart === -1 ? rest : rest.slice(0, footerStart).trim();
@@ -92,6 +92,13 @@ export const parseConventionalCommit = (message: string): ParsedCommit => {
     result.issues = issueMatches
       .map((m) => m.groups?.ref ?? "")
       .filter(Boolean);
+  }
+
+  const signoffMatch = /^Signed-off-by:(?<signoff>.+)$/m.exec(rest);
+  const signoff = signoffMatch?.groups?.signoff.trim();
+
+  if (signoff) {
+    result.signoff = signoff;
   }
 
   return result;

--- a/src/core/git/signoff.spec.ts
+++ b/src/core/git/signoff.spec.ts
@@ -1,0 +1,50 @@
+import { x } from "tinyexec";
+
+import { getSignoffTrailer } from "./signoff";
+
+vi.mock("tinyexec");
+
+describe("getSignoffTrailer", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should parse "Name <email>" from GIT_COMMITTER_IDENT', async () => {
+    vi.mocked(x).mockResolvedValue({
+      exitCode: 0,
+      stderr: "",
+      stdout: "Jane Doe <jane@example.com> 1700000000 -0700",
+    });
+
+    await expect(getSignoffTrailer()).resolves.toBe(
+      "Jane Doe <jane@example.com>",
+    );
+    expect(x).toHaveBeenCalledWith("git", ["var", "GIT_COMMITTER_IDENT"], {
+      throwOnError: true,
+    });
+  });
+
+  it("should trim surrounding whitespace before parsing", async () => {
+    vi.mocked(x).mockResolvedValue({
+      exitCode: 0,
+      stderr: "",
+      stdout: "  Jane Doe <jane@example.com> 1700000000 -0700\n",
+    });
+
+    await expect(getSignoffTrailer()).resolves.toBe(
+      "Jane Doe <jane@example.com>",
+    );
+  });
+
+  it("should return an empty string when git throws", async () => {
+    vi.mocked(x).mockRejectedValue(new Error("no identity"));
+
+    await expect(getSignoffTrailer()).resolves.toBe("");
+  });
+
+  it("should return an empty string when output has no identity", async () => {
+    vi.mocked(x).mockResolvedValue({ exitCode: 0, stderr: "", stdout: "" });
+
+    await expect(getSignoffTrailer()).resolves.toBe("");
+  });
+});

--- a/src/core/git/signoff.ts
+++ b/src/core/git/signoff.ts
@@ -1,0 +1,27 @@
+/**
+ * Git sign-off — resolve the committer identity for a Signed-off-by trailer
+ */
+
+import { x } from "tinyexec";
+
+/**
+ * Resolve the committer identity for a Signed-off-by trailer.
+ *
+ * Reads `git var GIT_COMMITTER_IDENT` ("Name <email> 1700000000 -0700") and
+ * returns just the "Name <email>" portion.
+ *
+ * @returns The committer identity, or "" when no git identity is configured
+ *   (so no trailer is added)
+ */
+export const getSignoffTrailer = async () => {
+  try {
+    const result = await x("git", ["var", "GIT_COMMITTER_IDENT"], {
+      throwOnError: true,
+    });
+    const match = /^(.*>)/.exec(result.stdout.trim());
+
+    return match?.[1] ?? "";
+  } catch {
+    return "";
+  }
+};

--- a/src/lang.spec.ts
+++ b/src/lang.spec.ts
@@ -41,6 +41,7 @@ describe("lang", () => {
         $ gitzy commit --type feat -m "add dark mode" --co-author "Jane Doe <jane@example.com>"
         $ gitzy commit --type feat -m "add dark mode" --dry-run
         $ gitzy commit --type feat -m "add dark mode" --no-emoji
+        $ gitzy commit --type feat -m "add dark mode" --signoff
         $ gitzy commit --amend
         $ gitzy commit --retry
           ",
@@ -57,6 +58,7 @@ describe("lang", () => {
             "noVerify": "Skip git hooks (--no-verify)",
             "retry": "Retry last commit and skip prompts",
             "scope": "Set scope inline",
+            "signoff": "Add a Signed-off-by trailer; pass a "Name <email>" to override your git identity",
             "stdin": "Read answers from stdin as JSON",
             "subject": "Set subject inline",
             "type": "Set type inline",

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -56,6 +56,7 @@ export const lang = {
   $ gitzy commit --type feat -m "add dark mode" --co-author "Jane Doe <jane@example.com>"
   $ gitzy commit --type feat -m "add dark mode" --dry-run
   $ gitzy commit --type feat -m "add dark mode" --no-emoji
+  $ gitzy commit --type feat -m "add dark mode" --signoff
   $ gitzy commit --amend
   $ gitzy commit --retry
     `,
@@ -73,6 +74,8 @@ export const lang = {
       noVerify: "Skip git hooks (--no-verify)",
       retry: "Retry last commit and skip prompts",
       scope: "Set scope inline",
+      signoff:
+        'Add a Signed-off-by trailer; pass a "Name <email>" to override your git identity',
       stdin: "Read answers from stdin as JSON",
       subject: "Set subject inline",
       type: "Set type inline",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--signoff` / `-s` commit flag with optional custom identity and interactive signoff prompt; commits can include a `Signed-off-by` trailer.

* **Behavior Changes**
  * Commit formatting and amend/parse logic now recognize and preserve signoff trailers.

* **Documentation**
  * README and CLI help updated to document signoff flag, prompt behavior, and examples.

* **Tests**
  * Added end-to-end and unit tests covering flag, prompt, trailer generation, formatting, and parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->